### PR TITLE
Set logger and wait time when creating nested MongoProxy object

### DIFF
--- a/mongodb_proxy.py
+++ b/mongodb_proxy.py
@@ -97,7 +97,7 @@ class MongoProxy:
         """
         item = self.conn[key]
         if hasattr(item, '__call__'):
-            return MongoProxy(item)
+            return MongoProxy(item, self.logger, self.wait_time)
         return item
 
     def __getattr__(self, key):
@@ -112,7 +112,7 @@ class MongoProxy:
             if key in EXECUTABLE_MONGO_METHODS:
                 return Executable(attr, self.logger, self.wait_time)
             else:
-                return MongoProxy(attr)
+                return MongoProxy(attr, self.logger, self.wait_time)
         return attr
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
When MongoProxy creates a new MongoProxy object, it needs to pass its own logger and wait_time settings into the new object.
