### PR TITLE
Update pymongo3_durable_cursor.py

### DIFF
--- a/mongo_proxy/pymongo3_durable_cursor.py
+++ b/mongo_proxy/pymongo3_durable_cursor.py
@@ -28,7 +28,7 @@ import time
 from pymongo.cursor import Cursor
 from pymongo.errors import AutoReconnect
 from pymongo.errors import NetworkTimeout
-from pymongo.errors import NotMasterError
+from pymongo.errors import NotPrimaryError
 
 logger = logging.getLogger(__name__)
 MAX_ATTEMPTS = 15

--- a/mongo_proxy/pymongo3_durable_cursor.py
+++ b/mongo_proxy/pymongo3_durable_cursor.py
@@ -28,7 +28,12 @@ import time
 from pymongo.cursor import Cursor
 from pymongo.errors import AutoReconnect
 from pymongo.errors import NetworkTimeout
-from pymongo.errors import NotPrimaryError
+
+# workaround to allow working with multiple versions of PyMongo
+if int(pymongo.version[0]) < 4:
+    from pymongo.errors import NotMasterError
+else:
+    from pymongo.errors import NotPrimaryError
 
 logger = logging.getLogger(__name__)
 MAX_ATTEMPTS = 15


### PR DESCRIPTION
NotMasterError has been removed/renamed a while back.
https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#notmastererror-is-removed